### PR TITLE
Allow custom DB URI using env var

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -3,7 +3,7 @@ const pgp = require("pg-promise")();
 
 const dmp = new DiffMatchPatch();
 
-const db = pgp("postgres://localhost:5432/busydb");
+const db = pgp(process.env.BUSYDB_URI || "postgres://localhost:5432/busydb");
 
 async function addUser(timestamp, username) {
   await db.none(


### PR DESCRIPTION
It may be difficult to start `sync` in different setups. So allowing to read from a custom env var would be good option to have.