### PR TITLE
Index transfers, increment balances, handle account update, post metadata and map others ops

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE posts (
   permlink VARCHAR(255),
   title VARCHAR(255),
   body TEXT,
+  metadata JSONB,
   CONSTRAINT uc_post UNIQUE (author, permlink)
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -6,7 +6,12 @@ CREATE TABLE accounts (
   owner JSONB,
   active JSONB,
   posting JSONB,
-  memo_key VARCHAR(255)
+  memo_key VARCHAR(255),
+  balance DECIMAL(50,3) DEFAULT 0,
+  sbd_balance DECIMAL(50,3) DEFAULT 0,
+  vesting_shares DECIMAL(50,6) DEFAULT 0,
+  delegated_vesting_shares DECIMAL(50,6) DEFAULT 0,
+  received_vesting_shares DECIMAL(50,6) DEFAULT 0
 );
 
 CREATE TABLE posts (
@@ -113,4 +118,13 @@ CREATE TABLE reblogs (
   account VARCHAR(16) NOT NULL,
   author VARCHAR(16),
   permlink VARCHAR(255)
+);
+
+CREATE TABLE transfers (
+  created_at TIMESTAMP,
+  transfer_from VARCHAR(16),
+  transfer_to VARCHAR(16),
+  amount DECIMAL(50,3),
+  asset VARCHAR(255),
+  memo TEXT
 );

--- a/src/db.js
+++ b/src/db.js
@@ -26,6 +26,31 @@ async function addUser(
   );
 }
 
+async function handleAccountUpdate(
+  timestamp,
+  account,
+  metadata,
+  owner,
+  active,
+  posting,
+  memoKey
+) {
+  let query = "UPDATE SET updated_at=$1, metadata=$2";
+  query += owner ? ", owner=$3" : "";
+  query += active ? ", active=$4" : "";
+  query += posting ? ", posting=$5" : "";
+  query += ", memo_key=$6 WHERE name=$7";
+  await db.none(query, [
+    timestamp,
+    JSON.stringify(metadata),
+    JSON.stringify(owner),
+    JSON.stringify(active),
+    JSON.stringify(posting),
+    memoKey,
+    account
+  ]);
+}
+
 async function addPost(
   timestamp,
   category,
@@ -279,5 +304,6 @@ module.exports = {
   addClaimRewardBalance,
   addDelegateVestingShares,
   handleReturnVestingDelegation,
-  addTransferToVesting
+  addTransferToVesting,
+  handleAccountUpdate
 };

--- a/src/db.js
+++ b/src/db.js
@@ -35,7 +35,7 @@ async function handleAccountUpdate(
   posting,
   memoKey
 ) {
-  let query = "UPDATE SET updated_at=$1, metadata=$2";
+  let query = "UPDATE accounts SET updated_at=$1, metadata=$2";
   query += owner ? ", owner=$3" : "";
   query += active ? ", active=$4" : "";
   query += posting ? ", posting=$5" : "";

--- a/src/sync.js
+++ b/src/sync.js
@@ -127,7 +127,7 @@ async function processBlock(header, txs) {
                 );
                 break;
               default:
-                console.log("Unhandled custom_json op", payload.json);
+                console.log("Unhandled custom_json follow op", payload.json);
                 break;
             }
           } else if (typeof json === "object") {
@@ -140,16 +140,18 @@ async function processBlock(header, txs) {
               );
             } else {
               console.log(
-                "Unhandled custom_json op with json object",
+                "Unhandled custom_json follow op with json object",
                 payload.json
               );
             }
           } else {
             console.log(
-              "Unhandled custom_json op with unknown json format",
+              "Unhandled custom_json follow op with unknown json format",
               payload.json
             );
           }
+        } else {
+          console.log("Unhandled custom_json op", payload);
         }
         break;
       case "producer_reward":
@@ -176,6 +178,57 @@ async function processBlock(header, txs) {
           payload.reward,
           payload.comment_author,
           payload.comment_permlink
+        );
+        break;
+      case "transfer":
+        await db.addTransfer(
+          timestamp,
+          payload.from,
+          payload.to,
+          payload.amount,
+          payload.memo,
+        );
+        break;
+      case "transfer_to_vesting":
+        await db.addTransferToVesting(payload.from, payload.to, payload.amount);
+        break;
+      case "fill_vesting_withdraw":
+        /* TODO {"from_account":"parachnen","to_account":"tard","withdrawn":"160.145659 VESTS","deposited":"0.078 STEEM"} */
+        break;
+      case "withdraw_vesting":
+        /* TODO {"account":"steemit","vesting_shares":"260000.000000 VESTS"} */
+        break;
+      case "limit_order_create":
+        /* TODO {"owner":"happychau123","orderid":120364126,"amount_to_sell":"226.222 SBD","min_to_receive":"196.714 STEEM","fill_or_kill":false,"expiration":"1903-08-13T16:38:24"} */
+        break;
+      case "fill_order":
+        /* TODO {"current_owner":"happychau123","current_orderid":120364126,"current_pays":"226.222 SBD","open_owner":"olorin","open_orderid":1524697587,"open_pays":"196.714 STEEM"} */
+        break;
+      case "claim_reward_balance":
+        await db.addClaimRewardBalance(
+          payload.account,
+          payload.reward_steem,
+          payload.reward_sbd,
+          payload.reward_vests
+        );
+        break;
+      case "account_update":
+        /* TODO {"account":"kobbari","posting":{"weight_threshold":1,"account_auths":[["dtube.app",1],["steem.app",1]],"key_auths":[["STM6chQJpEBLz416QLyQiHJ8K4GsktMFcHgD78LxdjnL29TEQGi5P",1]]},"memo_key":"STM7Yua1RSBymhxkFA6MYzZTMgJFThrAyerWBbBAyXiVRxP6S7u3i","json_metadata":""}] */
+        break;
+      case "account_witness_vote":
+        /* TODO {"account":"donalddrumpf","witness":"berniesanders","approve":true} */
+        break;
+      case "delegate_vesting_shares":
+        await db.addDelegateVestingShares(
+          payload.delegator,
+          payload.delegatee,
+          payload.vesting_shares
+        );
+        break;
+      case "return_vesting_delegation":
+        await db.handleReturnVestingDelegation(
+          payload.account,
+          payload.vesting_shares
         );
         break;
       default:

--- a/src/sync.js
+++ b/src/sync.js
@@ -74,13 +74,18 @@ async function processBlock(header, txs) {
       }
       case "comment":
         if (!payload.parent_author) {
+          let metadata = {};
+          try {
+            metadata = JSON.parse(payload.json_metadata);
+          } catch (e) {} // eslint-disable-line no-empty
           await db.addPost(
             timestamp,
             payload.parent_permlink,
             payload.author,
             payload.permlink,
             payload.title,
-            payload.body
+            payload.body,
+            metadata
           );
         } else {
           await db.addComment(

--- a/src/sync.js
+++ b/src/sync.js
@@ -217,9 +217,22 @@ async function processBlock(header, txs) {
           payload.reward_vests
         );
         break;
-      case "account_update":
-        /* TODO {"account":"kobbari","posting":{"weight_threshold":1,"account_auths":[["dtube.app",1],["steem.app",1]],"key_auths":[["STM6chQJpEBLz416QLyQiHJ8K4GsktMFcHgD78LxdjnL29TEQGi5P",1]]},"memo_key":"STM7Yua1RSBymhxkFA6MYzZTMgJFThrAyerWBbBAyXiVRxP6S7u3i","json_metadata":""}] */
+      case "account_update": {
+        let metadata = {};
+        try {
+          metadata = JSON.parse(payload.json_metadata);
+        } catch (e) {} // eslint-disable-line no-empty
+        await db.handleAccountUpdate(
+          timestamp,
+          payload.account,
+          metadata,
+          payload.owner,
+          payload.active,
+          payload.posting,
+          payload.memo_key
+        );
         break;
+      }
       case "account_witness_proxy":
         /* TODO {"account":"bunkermining","proxy":"datasecuritynode"} */
         break;

--- a/src/sync.js
+++ b/src/sync.js
@@ -215,6 +215,12 @@ async function processBlock(header, txs) {
       case "account_update":
         /* TODO {"account":"kobbari","posting":{"weight_threshold":1,"account_auths":[["dtube.app",1],["steem.app",1]],"key_auths":[["STM6chQJpEBLz416QLyQiHJ8K4GsktMFcHgD78LxdjnL29TEQGi5P",1]]},"memo_key":"STM7Yua1RSBymhxkFA6MYzZTMgJFThrAyerWBbBAyXiVRxP6S7u3i","json_metadata":""}] */
         break;
+      case "account_witness_proxy":
+        /* TODO {"account":"bunkermining","proxy":"datasecuritynode"} */
+        break;
+      case "feed_publish":
+        /* TODO {"publisher":"abit","exchange_rate":{"base":"1.000 SBD","quote":"1000.000 STEEM"}} */
+        break;
       case "account_witness_vote":
         /* TODO {"account":"donalddrumpf","witness":"berniesanders","approve":true} */
         break;

--- a/src/sync.js
+++ b/src/sync.js
@@ -242,6 +242,9 @@ async function processBlock(header, txs) {
       case "account_witness_vote":
         /* TODO {"account":"donalddrumpf","witness":"berniesanders","approve":true} */
         break;
+      case "witness_update":
+        /* TODO {"owner":"steempty","url":"fmooo/steemd-docker","block_signing_key":"STM8LoQjQqJHvotqBo7HjnqmUbFW9oJ2theyqonzUd9DdJ7YYHsvD","props":{"account_creation_fee":"100.000 STEEM","maximum_block_size":131072,"sbd_interest_rate":1000},"fee":"0.000 STEEM"} */
+        break;
       case "delegate_vesting_shares":
         await db.addDelegateVestingShares(
           payload.delegator,


### PR DESCRIPTION
Changes:
- Index transfers in new table
- Increment account balance based on multiple operations (vesting ops, rewards ops, transfer)
- Map unhandled operations
- Index post metadata with JSONB field
- Handle account update

Work in progress, i'm still replaying the chain from the beginning with header to test/catch some ops.